### PR TITLE
pystemd: remove unnecessary shebangs

### DIFF
--- a/pystemd/DBus/__init__.py
+++ b/pystemd/DBus/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/__init__.py
+++ b/pystemd/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/__version__.py
+++ b/pystemd/__version__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/base.py
+++ b/pystemd/base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/base.pyi
+++ b/pystemd/base.pyi
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2020-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/exceptions.py
+++ b/pystemd/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/machine1/__init__.py
+++ b/pystemd/machine1/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/machine1/machine.py
+++ b/pystemd/machine1/machine.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/machine1/manager.py
+++ b/pystemd/machine1/manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/run.py
+++ b/pystemd/run.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/__init__.py
+++ b/pystemd/systemd1/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/manager.py
+++ b/pystemd/systemd1/manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/manager.pyi
+++ b/pystemd/systemd1/manager.pyi
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2020-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/unit.py
+++ b/pystemd/systemd1/unit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/unit.pyi
+++ b/pystemd/systemd1/unit.pyi
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2020-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/systemd1/unit_signatures.py
+++ b/pystemd/systemd1/unit_signatures.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/utils.py
+++ b/pystemd/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.

--- a/pystemd/utils.pyi
+++ b/pystemd/utils.pyi
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright (c) 2017-present, Facebook, Inc.
 # All rights reserved.


### PR DESCRIPTION
These aren't actually needed and we already take them out in the Fedora package.