### PR TITLE
missing restart signature

### DIFF
--- a/pystemd/systemd1/unit_signatures.py
+++ b/pystemd/systemd1/unit_signatures.py
@@ -184,6 +184,7 @@ KNOWN_UNIT_SIGNATURES = {
     b"RestartPreventExitStatus": b"(aiai)",
     b"RestartForceExitStatus": b"(aiai)",
     b"SuccessExitStatus": b"(aiai)",
+    b"Restart": b"s",
     # Limits
     b"LimitCPU": b"t",
     b"LimitCPUSoft": b"t",


### PR DESCRIPTION

created a unit

```
In [7]: pystemd.run(["/bin/sleep", "infinity"], extra={"Restart": "always"}).Id
Out[7]: b'pystemd71fff13ca22d4168810c828cf6076e76.service'

```

and then check the unit

```
~ >>> systemctl cat pystemd71fff13ca22d4168810c828cf6076e76.service                      [1]
# /run/systemd/transient/pystemd71fff13ca22d4168810c828cf6076e76.service
# This is a transient unit file, created programmatically via the systemd API. Do not edit.
[Unit]
Description=pystemd: pystemd71fff13ca22d4168810c828cf6076e76.service

[Service]
ExecStart=
ExecStart="/bin/sleep" "infinity"
RemainAfterExit=no
Restart=always

```

restart is there... profit!