### PR TITLE
fix DBusRemote using the wrong attribute

### DIFF
--- a/pystemd/dbuslib.pyx
+++ b/pystemd/dbuslib.pyx
@@ -574,7 +574,7 @@ cdef class DBusRemote(DBus):
     self.host = host
 
   cdef int open_dbus_bus(self):
-    return dbusc.sd_bus_open_system_remote(&(self.bus), self.remote)
+    return dbusc.sd_bus_open_system_remote(&(self.bus), self.host)
 
 cdef class DBusAddress(DBus):
   "DBus class that connects to custom address"


### PR DESCRIPTION
fixes this:

```py
>>> bus = pystemd.dbuslib.DBusRemote(b'myhost')
>>> bus.open()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pystemd/dbuslib.pyx", line 303, in pystemd.dbuslib.DBus.open
    rets = self.open_dbus_bus()
  File "pystemd/dbuslib.pyx", line 577, in pystemd.dbuslib.DBusRemote.open_dbus_bus
    return dbusc.sd_bus_open_system_remote(&(self.bus), self.remote)
AttributeError: 'pystemd.dbuslib.DBusRemote' object has no attribute 'remote'
```