### PR TITLE
enable user_mode in futures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/examples/future_cpucap_pool.py
+++ b/examples/future_cpucap_pool.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -51,6 +52,7 @@ def main(cpu_quota=0.25):
     with TransientUnitPoolExecutor(
         properties={"CPUQuota": cpu_quota, "User": "nobody"},
         max_workers=10,
+        user_mode=os.getuid() != 0,
     ) as poold:
         top = MyTop(poold.unit)
         top.start()

--- a/pystemd/__version__.py
+++ b/pystemd/__version__.py
@@ -10,6 +10,6 @@ import sys
 
 # during development this version is always at least "one up" the
 # latest release.
-__version__ = "0.13.2"
+__version__ = "0.13.3"
 
 sys.modules[__name__] = __version__  # type: ignore

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -20,7 +20,7 @@ class TestFuturesRun(unittest.TestCase):
         poold = TransientUnitPoolExecutor.return_value.__enter__.return_value
         self.assertEqual(result, poold.submit.return_value.result.return_value)
         TransientUnitPoolExecutor.assert_called_once_with(
-            properties=properties, max_workers=1
+            properties=properties, max_workers=1, user_mode=False
         )
         poold.submit.assert_called_once_with(function, kwargs="kwarg")
 
@@ -31,7 +31,7 @@ class TestFuturesPool(unittest.TestCase):
         properties = Mock()
         context = TransientUnitContext.return_value
         with pystemd.futures.TransientUnitPoolExecutor(properties):
-            TransientUnitContext.assert_called_once_with(properties)
+            TransientUnitContext.assert_called_once_with(properties, user_mode=False)
             context.start_unit.assert_called_once()
         context.stop_unit.assert_called_once()
 
@@ -78,6 +78,7 @@ class TestTransientUnitProcess(unittest.TestCase):
         p.pre_run()
         TransientUnitContext.assert_called_once_with(
             properties=properties,
+            user_mode=False,
             main_process=[
                 "/bin/bash",
                 "-c",


### PR DESCRIPTION
allow futures to run in user_mode (on most systems, unless they are configure correctly, user_mode wont work... but i'm lucky that i get to work on a well configure env)