### PR TITLE
mark as uncompatible with python <3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -33,6 +31,7 @@ classifiers = [
 ]
 license = { text = "LGPL-2.1+" }
 keywords = ["systemd", "linux", "dbus"]
+requires-python = ">= 3.8"
 
 [project.optional-dependencies]
 # Used for runing tests


### PR DESCRIPTION
Hello,

When installing the latest tag with python 3.6 I am getting the following error :

```
    gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/tmp.7nSTVd4avl/venv/include -I/usr/include/python3.6m -c pystemd/journal.c -o build/temp.linux-x86_64-3.6/pystemd/journal.o
    pystemd/journal.c:31:6: error: #error Cython requires Python 3.8+.
         #error Cython requires Python 3.8+.
          ^~~~~
    error: command 'gcc' failed with exit status 1
```

I identified the change as a Cython update in your CI pipeline. C files are now generated using cython 3 since 0.13.4 making it incompatible with python 3.6 and 3.7.

If you want to maintain compatibility a solution is to force cython in version <3 during CI.